### PR TITLE
[mcp-tunnel] add handshaking

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "catalog:",
+        "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "@types/ws": "^8.18.1",
         "eslint": "catalog:",
@@ -111,6 +112,8 @@
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
+    "@types/bun": ["@types/bun@1.3.1", "", { "dependencies": { "bun-types": "1.3.1" } }, "sha512-4jNMk2/K9YJtfqwoAa28c8wK+T7nvJFOjxI4h/7sORWcypRNxBpr+TPNaCfVWq70tLCJsqoFwcf0oI0JU/fvMQ=="],
+
     "@types/eslint": ["@types/eslint@9.6.1", "", { "dependencies": { "@types/estree": "*", "@types/json-schema": "*" } }, "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag=="],
 
     "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
@@ -120,6 +123,8 @@
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
     "@types/node": ["@types/node@22.18.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ=="],
+
+    "@types/react": ["@types/react@19.2.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -183,6 +188,8 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "bun-types": ["bun-types@1.3.1", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-NMrcy7smratanWJ2mMXdpatalovtxVggkj11bScuWuiOoXTiKIu2eVS1/7qbyI/4yHedtsn175n4Sm4JcdHLXw=="],
+
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
@@ -212,6 +219,8 @@
     "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
 

--- a/packages/expo-mcp/src/cli.ts
+++ b/packages/expo-mcp/src/cli.ts
@@ -6,7 +6,7 @@ import { addMcpCapabilities } from './index.js';
 import { resolveProjectRoot } from './utils.js';
 
 const args = minimist(process.argv.slice(2), {
-  string: ['root', 'mcp-server-url'],
+  string: ['root', 'mcp-server-url', 'dev-server-url'],
   boolean: ['help', 'version'],
   alias: {
     h: 'help',
@@ -14,7 +14,8 @@ const args = minimist(process.argv.slice(2), {
   },
 });
 const programName = packageJson.name;
-const projectRoot = args.root ?? resolveProjectRoot();
+const projectRoot = (args.root as string | undefined) ?? resolveProjectRoot();
+const devServerUrl: string | undefined = args['dev-server-url'];
 
 if (args.help) {
   showHelp(programName);
@@ -24,10 +25,16 @@ if (args.version) {
   console.log(packageJson.version);
   process.exit(0);
 }
+if (!devServerUrl) {
+  console.error(`Error: required option '--dev-server-url <devServerUrl>' not specified`);
+  process.exit(1);
+}
 
 const server = args['mcp-server-url']
   ? new CompositeMcpServerProxy({
       tunnelServerUrl: args['mcp-server-url'],
+      projectRoot,
+      devServerUrl,
       stdioMcpServerName: packageJson.name,
       stdioMcpServerVersion: packageJson.version,
     })
@@ -47,14 +54,15 @@ function showHelp(programName: string) {
 Usage: ${programName} [options]
 
 Options:
-  -h, --help                Show help
-  -v, --version             Show version
-  --root                    The project root directory
-  --mcp-server-url          The URL of the MCP tunnel server to connect to
+  -h, --help                          Show help
+  -v, --version                       Show version
+  --dev-server-url <devServerUrl>     The URL of the running Expo dev server
+  --mcp-server-url <mcpServerUrl>     The URL of the MCP tunnel server to connect to
+  --root <projectRoot>                The project root directory (default: current working directory)
 
 Examples:
   # Start as stdio server (default)
-  ${programName}
+  ${programName} --dev-server-url http://localhost:8081
 `);
 }
 

--- a/packages/mcp-tunnel/package.json
+++ b/packages/mcp-tunnel/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
-    "lint": "eslint src"
+    "build": "tsc --project tsconfig.build.json",
+    "lint": "eslint src",
+    "test": "bun test",
+    "typecheck": "tsc"
   },
   "repository": {
     "type": "git",
@@ -25,6 +27,7 @@
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "catalog:",
+    "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "@types/ws": "^8.18.1",
     "eslint": "catalog:",

--- a/packages/mcp-tunnel/src/CompositeMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/CompositeMcpServerProxy.ts
@@ -11,10 +11,14 @@ export class CompositeMcpServerProxy implements McpServerProxy {
 
   constructor({
     tunnelServerUrl,
+    projectRoot,
+    devServerUrl,
     stdioMcpServerName,
     stdioMcpServerVersion,
   }: {
     tunnelServerUrl: string;
+    projectRoot: string;
+    devServerUrl: string;
     stdioMcpServerName?: string;
     stdioMcpServerVersion?: string;
   }) {
@@ -22,7 +26,10 @@ export class CompositeMcpServerProxy implements McpServerProxy {
       mcpServerName: stdioMcpServerName,
       mcpServerVersion: stdioMcpServerVersion,
     });
-    this.tunnelProxy = new TunnelMcpServerProxy(tunnelServerUrl);
+    this.tunnelProxy = new TunnelMcpServerProxy(tunnelServerUrl, {
+      projectRoot,
+      devServerUrl,
+    });
   }
 
   registerTool: McpServerProxy['registerTool'] = (name, config, callback) => {

--- a/packages/mcp-tunnel/src/TunnelMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/TunnelMcpServerProxy.ts
@@ -33,10 +33,12 @@ export class TunnelMcpServerProxy implements McpServerProxy {
   constructor(
     remoteUrl: string,
     options: {
+      projectRoot: string;
+      devServerUrl: string;
       reconnectInterval?: number;
       wsHeaders?: Record<string, string>;
       logger?: Logger;
-    } = {}
+    }
   ) {
     this.logger = options.logger ?? console;
     this.transport = new ReverseTunnelClientTransport(remoteUrl, options);
@@ -47,6 +49,10 @@ export class TunnelMcpServerProxy implements McpServerProxy {
       if (connected) {
         this.refreshAllRegistrations();
       }
+    };
+
+    this.transport.onServerAbort = (reason: string, closeCode?: number) => {
+      // no-op by default
     };
 
     // Set up message handler to route incoming requests to registered callbacks

--- a/packages/mcp-tunnel/src/__tests__/MockWebSocket.ts
+++ b/packages/mcp-tunnel/src/__tests__/MockWebSocket.ts
@@ -1,0 +1,31 @@
+export class MockWebSocket {
+  private eventHandlers: Map<string, Function[]> = new Map();
+
+  constructor(url: string, options?: { headers?: Record<string, string> }) {
+    setImmediate(() => {
+      this.trigger('open');
+    });
+  }
+
+  on(event: string, handler: Function) {
+    if (!this.eventHandlers.has(event)) {
+      this.eventHandlers.set(event, []);
+    }
+    this.eventHandlers.get(event)!.push(handler);
+  }
+
+  send(data: string) {
+    // Mock send method
+  }
+
+  close(code?: number, reason?: string) {
+    this.trigger('close', code ?? 1000, reason ?? 'Normal Closure');
+  }
+
+  private trigger(event: string, ...args: any[]) {
+    const handlers = this.eventHandlers.get(event);
+    if (handlers) {
+      handlers.forEach((handler) => handler(...args));
+    }
+  }
+}

--- a/packages/mcp-tunnel/src/__tests__/ReverseTunnelClientTransport.test.ts
+++ b/packages/mcp-tunnel/src/__tests__/ReverseTunnelClientTransport.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, mock, spyOn } from 'bun:test';
+import { ReverseTunnelClientTransport } from '../ReverseTunnelClientTransport';
+import {
+  JSON_RPC_VERSION,
+  WS_METHOD_HANDSHAKE,
+  WSTunnelCloseCode,
+  WSTunnelCloseMessage,
+} from '../constants';
+import { MockWebSocket } from './MockWebSocket';
+
+mock.module('ws', () => ({
+  default: MockWebSocket,
+}));
+
+const mockLogger = {
+  debug: mock(),
+  log: mock(),
+  info: mock(),
+  warn: mock(),
+  error: mock(),
+  time: mock(),
+  timeEnd: mock(),
+};
+
+describe(ReverseTunnelClientTransport, () => {
+  it('should send handshake with correct data when connected', async () => {
+    const projectRoot = '/app';
+    const devServerUrl = 'http://localhost:8081';
+    const transport = new ReverseTunnelClientTransport('ws://localhost:8080', {
+      projectRoot,
+      devServerUrl,
+      logger: mockLogger,
+    });
+
+    const sendSpy = spyOn(transport, 'send').mockResolvedValue(undefined);
+
+    await transport.start();
+
+    expect(sendSpy).toHaveBeenCalledWith({
+      jsonrpc: JSON_RPC_VERSION,
+      method: WS_METHOD_HANDSHAKE,
+      params: { projectRoot, devServerUrl },
+    });
+  });
+
+  it('should reconnect by default on disconnection', async () => {
+    const projectRoot = '/app';
+    const devServerUrl = 'http://localhost:8081';
+    const transport = new ReverseTunnelClientTransport('ws://localhost:8080', {
+      projectRoot,
+      devServerUrl,
+      reconnectInterval: 100,
+      logger: mockLogger,
+    });
+
+    // @ts-expect-error: access private property for testing
+    const spyConnect = spyOn(transport, 'connect');
+    await transport.start();
+
+    // @ts-expect-error: access private property for testing
+    const ws = transport['ws'] as MockWebSocket;
+    ws.close();
+
+    // Wait a moment for reconnect logic to trigger
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // Initial connect + 1 reconnect
+    expect(spyConnect).toHaveBeenCalledTimes(2);
+  });
+
+  it('should abort connection on server close 4003', async () => {
+    const projectRoot = '/app';
+    const devServerUrl = 'http://localhost:8081';
+    const transport = new ReverseTunnelClientTransport('ws://localhost:8080', {
+      projectRoot,
+      devServerUrl,
+      reconnectInterval: 100,
+      logger: mockLogger,
+    });
+    const mockOnServerAbort = mock();
+    transport.onServerAbort = mockOnServerAbort;
+
+    // @ts-expect-error: access private property for testing
+    const spyConnect = spyOn(transport, 'connect');
+    await transport.start();
+
+    // @ts-expect-error: access private property for testing
+    const ws = transport['ws'] as MockWebSocket;
+    ws.close(4003, 'Multiple tunnel clients are not supported yet');
+
+    expect(mockOnServerAbort).toHaveBeenCalledTimes(1);
+    expect(mockOnServerAbort).toHaveBeenCalledWith(
+      WSTunnelCloseMessage[WSTunnelCloseCode.MULTIPLE_CLIENTS_CONNECTED],
+      WSTunnelCloseCode.MULTIPLE_CLIENTS_CONNECTED
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(spyConnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mcp-tunnel/src/constants.ts
+++ b/packages/mcp-tunnel/src/constants.ts
@@ -4,6 +4,11 @@
 export const JSON_RPC_VERSION = '2.0';
 
 /**
+ * WebSocket method: handshake to send initial client information (client -> server)
+ */
+export const WS_METHOD_HANDSHAKE = 'handshake';
+
+/**
  * WebSocket method: to register MCP tool (client -> server)
  */
 export const WS_METHOD_REGISTER_MCP_TOOL = 'register_mcp_tool';
@@ -32,3 +37,64 @@ export const WS_METHOD_MCP_PROMPTS_GET = 'prompts/get';
  * WebSocket method: read MCP resource (server -> client)
  */
 export const WS_METHOD_MCP_RESOURCES_READ = 'resources/read';
+
+/**
+ * Custom WebSocket close codes for MCP tunnel.
+ * These codes are in the 4000-4999 range reserved for application use.
+ * Standard close codes: https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1
+ */
+export enum WSTunnelCloseCode {
+  /**
+   * Standard close code: Policy Violation (e.g., authentication failure).
+   * This is a standard WebSocket close code (1008).
+   */
+  POLICY_VIOLATION = 1008,
+
+  /**
+   * Unknown error.
+   */
+  UNKNOWN_ERROR = 4000,
+
+  /**
+   * Server is shutting down gracefully.
+   */
+  SERVER_SHUTDOWN = 4001,
+
+  /**
+   * Client is banned or blocked from connecting.
+   */
+  CLIENT_BANNED = 4002,
+
+  /**
+   * Multiple tunnel clients are not supported yet.
+   */
+  MULTIPLE_CLIENTS_CONNECTED = 4003,
+
+  /**
+   * Client is possibly stale and needs to reconnect manually.
+   */
+  STALE_CLIENT = 4004,
+}
+
+/**
+ * Error messages corresponding to each WebSocket close code.
+ */
+export const WSTunnelCloseMessage: Record<WSTunnelCloseCode, string> = {
+  [WSTunnelCloseCode.POLICY_VIOLATION]: 'Connection closed due to policy violation',
+  [WSTunnelCloseCode.UNKNOWN_ERROR]: 'Unknown error',
+  [WSTunnelCloseCode.SERVER_SHUTDOWN]: 'Server is shutting down',
+  [WSTunnelCloseCode.CLIENT_BANNED]: 'Client is banned or blocked from connecting',
+  [WSTunnelCloseCode.MULTIPLE_CLIENTS_CONNECTED]: 'Multiple tunnel clients are not supported yet',
+  [WSTunnelCloseCode.STALE_CLIENT]: 'Client is possibly stale and needs to reconnect manually',
+};
+
+/**
+ * Set of WebSocket close codes that should NOT trigger automatic reconnection.
+ * These represent permanent failures that require manual intervention.
+ */
+export const NON_RECONNECTABLE_CLOSE_CODES = new Set<number>([
+  WSTunnelCloseCode.POLICY_VIOLATION,
+  WSTunnelCloseCode.CLIENT_BANNED,
+  WSTunnelCloseCode.MULTIPLE_CLIENTS_CONNECTED,
+  WSTunnelCloseCode.STALE_CLIENT,
+]);

--- a/packages/mcp-tunnel/tsconfig.build.json
+++ b/packages/mcp-tunnel/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "exclude": ["node_modules", "dist", "src/**/__tests__/*"]
+}

--- a/packages/mcp-tunnel/tsconfig.json
+++ b/packages/mcp-tunnel/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
# Why

the server cannot reliably detect abnormal closing connection and having stale connection

# How

- add tunnel handshaking with `projectRoot` and `devServerUrl` as handshaking parameters
- define websocket close code, for some server force closing code, we should not reconnect

# Test Plan

add unit tests

```
packages/mcp-tunnel/src/__tests__/ReverseTunnelClientTransport.test.ts:
✓ ReverseTunnelClientTransport > should send handshake with correct data when connected [0.46ms]
✓ ReverseTunnelClientTransport > should reconnect by default on disconnection [200.92ms]
✓ ReverseTunnelClientTransport > should abort connection on server close 4003 [201.36ms]
``` 