### PR TITLE
[tunnel] fix backward compatibility for 0.1

### DIFF
--- a/packages/mcp-tunnel/src/CompositeMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/CompositeMcpServerProxy.ts
@@ -64,6 +64,9 @@ export class CompositeMcpServerProxy implements McpServerProxy {
   }
 
   get devServerUrl(): string {
-    return this._devServerUrl;
+    // To support backward compatibility that mcp-tunnel@~0.1.0 does not pass the devServerUrl to the constructor.
+    // We try to get the devServerUrl from the transport.
+    // TODO(kudo,20251127): Remove this once mcp-tunnel@~0.1.0 is no longer supported.
+    return this._devServerUrl ?? this.tunnelProxy.devServerUrl;
   }
 }

--- a/packages/mcp-tunnel/src/ReverseTunnelClientTransport.ts
+++ b/packages/mcp-tunnel/src/ReverseTunnelClientTransport.ts
@@ -65,6 +65,10 @@ export class ReverseTunnelClientTransport implements Transport {
     await this.connect();
   }
 
+  get devServerUrl(): string {
+    return this.handshakeData.devServerUrl;
+  }
+
   private async connect(): Promise<void> {
     try {
       this.logger.debug(`[MCP] Connecting to remote MCP tunnel server at ${this.remoteUrl}...`);

--- a/packages/mcp-tunnel/src/TunnelMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/TunnelMcpServerProxy.ts
@@ -72,7 +72,10 @@ export class TunnelMcpServerProxy implements McpServerProxy {
   }
 
   get devServerUrl(): string {
-    return this._devServerUrl;
+    // To support backward compatibility that mcp-tunnel@~0.1.0 does not pass the devServerUrl to the constructor.
+    // We try to get the devServerUrl from the transport.
+    // TODO(kudo,20251127): Remove this once mcp-tunnel@~0.1.0 is no longer supported.
+    return this._devServerUrl ?? this.transport.devServerUrl;
   }
 
   registerTool: McpServerProxy['registerTool'] = (name, config, callback) => {


### PR DESCRIPTION
# Why

expo-cli still has mcp-tunnel 0.1 that doesn't pass the `devServerUrl` to server constructor. new mcp cabilities doesn't work because devServerUrl is undefined

# How

try to retrieve the devServerUrl from the transport

# Test Plan

try to publish and verify on expo-cli