### PR TITLE
[mcp] add support for sending/receiving client info

### DIFF
--- a/packages/mcp-tunnel/src/CompositeMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/CompositeMcpServerProxy.ts
@@ -1,6 +1,6 @@
 import { StdioMcpServerProxy } from './StdioMcpServerProxy.js';
 import { TunnelMcpServerProxy } from './TunnelMcpServerProxy.js';
-import { McpServerProxy } from './types.js';
+import { type McpClientInfo, McpServerProxy } from './types.js';
 
 /**
  * A MCP server proxy that serves MCP capabilities for both `StdioMcpServerProxy` and `TunnelMcpServerProxy`.
@@ -33,6 +33,11 @@ export class CompositeMcpServerProxy implements McpServerProxy {
       projectRoot,
       devServerUrl,
     });
+
+    // Forward stdio client info to the tunnel server when detected
+    this.stdioProxy.onMcpClientInfoChanged = (clientInfo) => {
+      this.tunnelProxy.sendMcpClientInfo(clientInfo);
+    };
   }
 
   registerTool: McpServerProxy['registerTool'] = (name, config, callback) => {
@@ -68,5 +73,10 @@ export class CompositeMcpServerProxy implements McpServerProxy {
     // We try to get the devServerUrl from the transport.
     // TODO(kudo,20251127): Remove this once mcp-tunnel@~0.1.0 is no longer supported.
     return this._devServerUrl ?? this.tunnelProxy.devServerUrl;
+  }
+
+  get mcpClientInfo(): McpClientInfo | null {
+    // Prefer stdio client info (local IDE connection) over tunnel client info
+    return this.stdioProxy.mcpClientInfo ?? this.tunnelProxy.mcpClientInfo;
   }
 }

--- a/packages/mcp-tunnel/src/CompositeMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/CompositeMcpServerProxy.ts
@@ -1,6 +1,6 @@
 import { StdioMcpServerProxy } from './StdioMcpServerProxy.js';
 import { TunnelMcpServerProxy } from './TunnelMcpServerProxy.js';
-import { type McpClientInfo, McpServerProxy } from './types.js';
+import { type McpClientInfo, type McpServerProxy } from './types.js';
 
 /**
  * A MCP server proxy that serves MCP capabilities for both `StdioMcpServerProxy` and `TunnelMcpServerProxy`.

--- a/packages/mcp-tunnel/src/CompositeMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/CompositeMcpServerProxy.ts
@@ -33,11 +33,6 @@ export class CompositeMcpServerProxy implements McpServerProxy {
       projectRoot,
       devServerUrl,
     });
-
-    // Forward stdio client info to the tunnel server when detected
-    this.stdioProxy.onMcpClientInfoChanged = (clientInfo) => {
-      this.tunnelProxy.sendMcpClientInfo(clientInfo);
-    };
   }
 
   registerTool: McpServerProxy['registerTool'] = (name, config, callback) => {

--- a/packages/mcp-tunnel/src/StdioMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/StdioMcpServerProxy.ts
@@ -16,11 +16,6 @@ export class StdioMcpServerProxy implements McpServerProxy {
   private readonly transport = new StdioServerTransport();
   private _mcpClientInfo: McpClientInfo | null = null;
 
-  /**
-   * Callback invoked when the MCP client info is detected from stdio connection.
-   */
-  onMcpClientInfoChanged?: (clientInfo: McpClientInfo | null) => void;
-
   constructor({
     devServerUrl,
     mcpServerName = 'Expo MCP Server',
@@ -44,7 +39,6 @@ export class StdioMcpServerProxy implements McpServerProxy {
           name: clientVersion.name,
           version: clientVersion.version,
         };
-        this.onMcpClientInfoChanged?.(this._mcpClientInfo);
       }
     };
   }

--- a/packages/mcp-tunnel/src/StdioMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/StdioMcpServerProxy.ts
@@ -5,7 +5,7 @@ import {
 } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
-import { type McpServerProxy } from './types.js';
+import { type McpClientInfo, type McpServerProxy } from './types.js';
 
 /**
  * A MCP server proxy that serves MCP capabilities as the stdio server transport.
@@ -14,6 +14,12 @@ export class StdioMcpServerProxy implements McpServerProxy {
   private readonly _devServerUrl: string;
   private readonly server;
   private readonly transport = new StdioServerTransport();
+  private _mcpClientInfo: McpClientInfo | null = null;
+
+  /**
+   * Callback invoked when the MCP client info is detected from stdio connection.
+   */
+  onMcpClientInfoChanged?: (clientInfo: McpClientInfo | null) => void;
 
   constructor({
     devServerUrl,
@@ -29,6 +35,18 @@ export class StdioMcpServerProxy implements McpServerProxy {
       name: mcpServerName,
       version: mcpServerVersion,
     });
+
+    // Capture client info when the MCP client initializes
+    this.server.server.oninitialized = () => {
+      const clientVersion = this.server.server.getClientVersion();
+      if (clientVersion) {
+        this._mcpClientInfo = {
+          name: clientVersion.name,
+          version: clientVersion.version,
+        };
+        this.onMcpClientInfoChanged?.(this._mcpClientInfo);
+      }
+    };
   }
 
   registerTool: McpServerProxy['registerTool'] = (name, config, callback) => {
@@ -72,5 +90,9 @@ export class StdioMcpServerProxy implements McpServerProxy {
 
   get devServerUrl(): string {
     return this._devServerUrl;
+  }
+
+  get mcpClientInfo(): McpClientInfo | null {
+    return this._mcpClientInfo;
   }
 }

--- a/packages/mcp-tunnel/src/TunnelMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/TunnelMcpServerProxy.ts
@@ -4,6 +4,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 import { ReverseTunnelClientTransport } from './ReverseTunnelClientTransport.js';
 import {
   JSON_RPC_VERSION,
+  WS_METHOD_CLIENT_INFO,
   WS_METHOD_MCP_PROMPTS_GET,
   WS_METHOD_MCP_RESOURCES_READ,
   WS_METHOD_MCP_TOOLS_CALL,
@@ -13,6 +14,7 @@ import {
 } from './constants.js';
 import {
   type Logger,
+  type McpClientInfo,
   type McpServerProxy,
   type SerializedMcpPrompt,
   type SerializedMcpResource,
@@ -30,6 +32,12 @@ export class TunnelMcpServerProxy implements McpServerProxy {
   private registeredPrompts = new Map<string, SerializedMcpPrompt & { callback: any }>();
   private registeredResources = new Map<string, SerializedMcpResource & { callback: any }>();
   private isConnected = false;
+  private _mcpClientInfo: McpClientInfo | null = null;
+
+  /**
+   * Callback invoked when the MCP client info changes (e.g., when a new client connects).
+   */
+  onMcpClientInfoChanged?: (clientInfo: McpClientInfo | null) => void;
 
   constructor(
     remoteUrl: string,
@@ -50,6 +58,10 @@ export class TunnelMcpServerProxy implements McpServerProxy {
       this.isConnected = connected;
       if (connected) {
         this.refreshAllRegistrations();
+        // Send any cached client info when connection is established
+        if (this._mcpClientInfo) {
+          this.sendMcpClientInfoInternal(this._mcpClientInfo);
+        }
       }
     };
 
@@ -201,6 +213,34 @@ export class TunnelMcpServerProxy implements McpServerProxy {
     }
   }
 
+  /**
+   * Caches and sends the MCP client info to the tunnel server.
+   * If not connected, caches for later when connection is established.
+   */
+  async sendMcpClientInfo(clientInfo: McpClientInfo | null): Promise<void> {
+    // Always cache the client info
+    this._mcpClientInfo = clientInfo;
+
+    if (this.isConnected) {
+      await this.sendMcpClientInfoInternal(clientInfo);
+    }
+  }
+
+  /**
+   * Internal method to send client info without caching.
+   */
+  private async sendMcpClientInfoInternal(clientInfo: McpClientInfo | null): Promise<void> {
+    try {
+      await this.transport.send({
+        jsonrpc: JSON_RPC_VERSION,
+        method: WS_METHOD_CLIENT_INFO,
+        params: (clientInfo ?? {}) as Record<string, unknown>,
+      });
+    } catch (error) {
+      this.logger.error('[MCP] Failed to send client info:', error);
+    }
+  }
+
   // Getter methods for accessing registered items (useful for debugging/inspection)
   getRegisteredTools(): ReadonlyMap<string, SerializedMcpTool> {
     return new Map(
@@ -224,8 +264,27 @@ export class TunnelMcpServerProxy implements McpServerProxy {
     return this.isConnected;
   }
 
+  /**
+   * Returns the current MCP client info, or null if not yet received.
+   */
+  get mcpClientInfo(): McpClientInfo | null {
+    return this._mcpClientInfo;
+  }
+
   private async handleIncomingMessage(message: any): Promise<void> {
     try {
+      // Handle handshake response (contains mcpClientInfo)
+      if (message.result && 'mcpClientInfo' in message.result) {
+        this.updateMcpClientInfo(message.result.mcpClientInfo);
+        return;
+      }
+
+      // Handle client/info notification (no id, just method)
+      if (message.method === WS_METHOD_CLIENT_INFO && !message.id) {
+        this.updateMcpClientInfo(message.params as McpClientInfo | null);
+        return;
+      }
+
       // Only handle JSON-RPC requests (messages with id and method)
       if (!message.id || !message.method) {
         return;
@@ -315,5 +374,10 @@ export class TunnelMcpServerProxy implements McpServerProxy {
     }
 
     return await matchedResource.callback(uri);
+  }
+
+  private updateMcpClientInfo(clientInfo: McpClientInfo | null): void {
+    this._mcpClientInfo = clientInfo;
+    this.onMcpClientInfoChanged?.(clientInfo);
   }
 }

--- a/packages/mcp-tunnel/src/TunnelMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/TunnelMcpServerProxy.ts
@@ -5,6 +5,7 @@ import { ReverseTunnelClientTransport } from './ReverseTunnelClientTransport.js'
 import {
   JSON_RPC_VERSION,
   WS_METHOD_CLIENT_INFO,
+  WS_METHOD_HANDSHAKE_RESPONSE,
   WS_METHOD_MCP_PROMPTS_GET,
   WS_METHOD_MCP_RESOURCES_READ,
   WS_METHOD_MCP_TOOLS_CALL,
@@ -236,13 +237,13 @@ export class TunnelMcpServerProxy implements McpServerProxy {
 
   private async handleIncomingMessage(message: any): Promise<void> {
     try {
-      // Handle handshake response (contains mcpClientInfo)
-      if (message.result && 'mcpClientInfo' in message.result) {
-        this.updateMcpClientInfo(message.result.mcpClientInfo);
+      // Handle handshake response (server -> client)
+      if (message.method === WS_METHOD_HANDSHAKE_RESPONSE) {
+        this.updateMcpClientInfo(message.params?.mcpClientInfo as McpClientInfo | null);
         return;
       }
 
-      // Handle client/info notification (no id, just method)
+      // Handle client/info notification (server -> client, no id)
       if (message.method === WS_METHOD_CLIENT_INFO && !message.id) {
         this.updateMcpClientInfo(message.params as McpClientInfo | null);
         return;

--- a/packages/mcp-tunnel/src/TunnelMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/TunnelMcpServerProxy.ts
@@ -34,11 +34,6 @@ export class TunnelMcpServerProxy implements McpServerProxy {
   private isConnected = false;
   private _mcpClientInfo: McpClientInfo | null = null;
 
-  /**
-   * Callback invoked when the MCP client info changes (e.g., when a new client connects).
-   */
-  onMcpClientInfoChanged?: (clientInfo: McpClientInfo | null) => void;
-
   constructor(
     remoteUrl: string,
     options: {
@@ -58,10 +53,6 @@ export class TunnelMcpServerProxy implements McpServerProxy {
       this.isConnected = connected;
       if (connected) {
         this.refreshAllRegistrations();
-        // Send any cached client info when connection is established
-        if (this._mcpClientInfo) {
-          this.sendMcpClientInfoInternal(this._mcpClientInfo);
-        }
       }
     };
 
@@ -213,34 +204,6 @@ export class TunnelMcpServerProxy implements McpServerProxy {
     }
   }
 
-  /**
-   * Caches and sends the MCP client info to the tunnel server.
-   * If not connected, caches for later when connection is established.
-   */
-  async sendMcpClientInfo(clientInfo: McpClientInfo | null): Promise<void> {
-    // Always cache the client info
-    this._mcpClientInfo = clientInfo;
-
-    if (this.isConnected) {
-      await this.sendMcpClientInfoInternal(clientInfo);
-    }
-  }
-
-  /**
-   * Internal method to send client info without caching.
-   */
-  private async sendMcpClientInfoInternal(clientInfo: McpClientInfo | null): Promise<void> {
-    try {
-      await this.transport.send({
-        jsonrpc: JSON_RPC_VERSION,
-        method: WS_METHOD_CLIENT_INFO,
-        params: (clientInfo ?? {}) as Record<string, unknown>,
-      });
-    } catch (error) {
-      this.logger.error('[MCP] Failed to send client info:', error);
-    }
-  }
-
   // Getter methods for accessing registered items (useful for debugging/inspection)
   getRegisteredTools(): ReadonlyMap<string, SerializedMcpTool> {
     return new Map(
@@ -378,6 +341,5 @@ export class TunnelMcpServerProxy implements McpServerProxy {
 
   private updateMcpClientInfo(clientInfo: McpClientInfo | null): void {
     this._mcpClientInfo = clientInfo;
-    this.onMcpClientInfoChanged?.(clientInfo);
   }
 }

--- a/packages/mcp-tunnel/src/constants.ts
+++ b/packages/mcp-tunnel/src/constants.ts
@@ -39,6 +39,11 @@ export const WS_METHOD_MCP_PROMPTS_GET = 'prompts/get';
 export const WS_METHOD_MCP_RESOURCES_READ = 'resources/read';
 
 /**
+ * WebSocket method: notify about updated client info (from server -> client)
+ */
+export const WS_METHOD_CLIENT_INFO = 'client/info';
+
+/**
  * Custom WebSocket close codes for MCP tunnel.
  * These codes are in the 4000-4999 range reserved for application use.
  * Standard close codes: https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1

--- a/packages/mcp-tunnel/src/constants.ts
+++ b/packages/mcp-tunnel/src/constants.ts
@@ -44,6 +44,11 @@ export const WS_METHOD_MCP_RESOURCES_READ = 'resources/read';
 export const WS_METHOD_CLIENT_INFO = 'client/info';
 
 /**
+ * WebSocket method: handshake response from server to client (server -> client)
+ */
+export const WS_METHOD_HANDSHAKE_RESPONSE = 'handshake_response';
+
+/**
  * Custom WebSocket close codes for MCP tunnel.
  * These codes are in the 4000-4999 range reserved for application use.
  * Standard close codes: https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1

--- a/packages/mcp-tunnel/src/index.ts
+++ b/packages/mcp-tunnel/src/index.ts
@@ -3,4 +3,4 @@ export * from './ReverseTunnelClientTransport.js';
 export * from './StdioMcpServerProxy.js';
 export * from './TunnelMcpServerProxy.js';
 export * from './constants.js';
-export type * from './types.d.ts';
+export * from './types.js';

--- a/packages/mcp-tunnel/src/types.ts
+++ b/packages/mcp-tunnel/src/types.ts
@@ -126,29 +126,6 @@ export interface Logger {
 }
 
 /**
- * Predefined known MCP client types.
- * Reference https://github.com/apify/mcp-client-capabilities for adding more clients.
- */
-export enum McpClientType {
-  ClaudeCode = 'claude-code',
-  Cursor = 'cursor-vscode',
-  VSCode = 'Visual Studio Code',
-}
-
-/**
- * Create an McpClientType from a given client name string.
- * Returns undefined if the client name is not recognized.
- */
-export function createMcpClientType(name: string): McpClientType | undefined {
-  for (const value of Object.values(McpClientType)) {
-    if (name.includes(value)) {
-      return value;
-    }
-  }
-  return undefined;
-}
-
-/**
  * Information about the connected MCP client (e.g., Claude, VS Code, Cursor).
  */
 export interface McpClientInfo {

--- a/packages/mcp-tunnel/src/types.ts
+++ b/packages/mcp-tunnel/src/types.ts
@@ -80,6 +80,11 @@ export interface McpServerProxy {
    * Gets the URL of the dev server.
    */
   get devServerUrl(): string;
+
+  /**
+   * Gets the current MCP client info (e.g., Claude, VS Code, Cursor), or null if not yet received.
+   */
+  get mcpClientInfo(): McpClientInfo | null;
 }
 
 export type SerializedSchema = object;
@@ -118,4 +123,35 @@ export interface Logger {
   error(...message: any[]): void;
   time(label: string): void;
   timeEnd(label: string): void;
+}
+
+/**
+ * Predefined known MCP client types.
+ * Reference https://github.com/apify/mcp-client-capabilities for adding more clients.
+ */
+export enum McpClientType {
+  ClaudeCode = 'claude-code',
+  Cursor = 'cursor-vscode',
+  VSCode = 'Visual Studio Code',
+}
+
+/**
+ * Create an McpClientType from a given client name string.
+ * Returns undefined if the client name is not recognized.
+ */
+export function createMcpClientType(name: string): McpClientType | undefined {
+  for (const value of Object.values(McpClientType)) {
+    if (name.includes(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Information about the connected MCP client (e.g., Claude, VS Code, Cursor).
+ */
+export interface McpClientInfo {
+  name: string;
+  version: string;
 }


### PR DESCRIPTION
## Why

The local mcp capabilities needs knowledge about the environment that the current session in running in so that it can create files in the correct locations depending on the tool it is running under.

This would typically be used for updating configuration files that helps our users with their Expo development through agent configuration like skill files that is expected to be located in slightly different places depending on wether we're in VSCode, Claude Code or Cursor.

## How

This is implemented by adding the name/version as clientinfo on the McpServerProxy class, and exposing the property `mcpClientInfo`. Both the CompositeMcpServerProxy, StdioMcpServerProxy and the TunnelMcpServerProxy now implements this method.

The TunnelMcpServerProxy is also handling storing this information and passing it on to the mcp server.

Tested in cursor/claude code and vscode.