### PR TITLE
update deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
       },
       "dependencies": {
         "@expo/mcp-tunnel": "workspace:~",
+        "@modelcontextprotocol/sdk": "catalog:",
         "debug": "^4.4.3",
         "glob": "^11.0.3",
         "jimp-compact": "0.16.1",
@@ -42,17 +43,20 @@
       "name": "@expo/mcp-tunnel",
       "version": "0.2.3",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "catalog:",
         "ws": "catalog:",
         "zod": "catalog:",
         "zod-to-json-schema": "^3.24.6",
       },
       "devDependencies": {
+        "@modelcontextprotocol/sdk": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "@types/ws": "catalog:",
         "prettier": "catalog:",
         "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.26.0",
       },
     },
   },
@@ -802,7 +806,7 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "zx": ["zx@8.8.1", "", { "bin": { "zx": "build/cli.js" } }, "sha512-qvsKBnvWHstHKCluKPlEgI/D3+mdiQyMoSSeFR8IX/aXzWIas5A297KxKgPJhuPXdrR6ma0Jzx43+GQ/8sqbrw=="],
 
@@ -819,8 +823,6 @@
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "@modelcontextprotocol/sdk/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "@types/ws/@types/node": ["@types/node@22.15.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw=="],
 

--- a/packages/expo-mcp/package.json
+++ b/packages/expo-mcp/package.json
@@ -33,6 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "@expo/mcp-tunnel": "workspace:~",
+    "@modelcontextprotocol/sdk": "catalog:",
     "debug": "^4.4.3",
     "glob": "^11.0.3",
     "jimp-compact": "0.16.1",

--- a/packages/mcp-tunnel/package.json
+++ b/packages/mcp-tunnel/package.json
@@ -21,16 +21,19 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "catalog:",
     "ws": "catalog:",
     "zod-to-json-schema": "^3.24.6",
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "catalog:",
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "@types/ws": "catalog:",
     "prettier": "catalog:",
     "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0"
   }
 }


### PR DESCRIPTION
# Why

try to decouple `@modelcontextprotocol/sdk` from mcp-tunnel. second try for reverting #6 

# How

- mcp-tunnel: use devDeps and peerDeps again. removing `peerDependenciesMeta: { optional: true }` this time
- expo-mcp: add deps again

# Test Plan

may publish expo-mcp and try stdio transport by bunx