### PR TITLE
feat: in-app runtime bridge with pluggable handler system

### DIFF
--- a/packages/expo-mcp/package.json
+++ b/packages/expo-mcp/package.json
@@ -4,6 +4,10 @@
   "description": "Local MCP capabilities provider for Expo",
   "main": "dist/index.js",
   "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./runtime": "./src/runtime/index.ts"
+  },
   "bin": {
     "expo-mcp": "bin/expo-mcp.mjs"
   },
@@ -27,7 +31,8 @@
   "files": [
     "assets/**/*",
     "bin",
-    "dist"
+    "dist",
+    "src/runtime/**/*"
   ],
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-mcp/src/develop/RuntimeClient.ts
+++ b/packages/expo-mcp/src/develop/RuntimeClient.ts
@@ -1,0 +1,193 @@
+import createDebug from "debug";
+import { WebSocket } from "ws";
+
+const debug = createDebug("expo-mcp:runtime");
+const PLUGIN_NAME = "expo-mcp-runtime";
+
+interface PendingRequest {
+  resolve: (value: any) => void;
+  reject: (error: Error) => void;
+  timeout: NodeJS.Timeout;
+}
+
+export class RuntimeClient {
+  private ws: WebSocket | null = null;
+  private pending = new Map<string, PendingRequest>();
+  private connected = false;
+  private browserClientId = crypto.randomUUID();
+  private readyResolvers: Array<() => void> = [];
+  private ready = false;
+
+  readonly devServerUrl: string;
+
+  constructor(devServerUrl: string) {
+    this.devServerUrl = devServerUrl;
+  }
+
+  /**
+   * Connect to the devtools broadcast WebSocket.
+   * This connects to Metro but doesn't mean the app is ready —
+   * the app signals readiness by sending a "bridge_ready" message
+   * when ExpoMCPDevTools mounts.
+   */
+  async connectAsync(): Promise<boolean> {
+    try {
+      const wsUrl = `${this.devServerUrl.replace("http", "ws")}/expo-dev-plugins/broadcast`;
+      debug(`Connecting to devtools broadcast: ${wsUrl}`);
+
+      this.ws = new WebSocket(wsUrl);
+
+      return new Promise((resolve) => {
+        const timeout = setTimeout(() => {
+          debug("WebSocket connection timeout");
+          this.ws?.close();
+          resolve(false);
+        }, 3000);
+
+        this.ws!.on("open", () => {
+          debug("WebSocket open, sending handshake");
+          this.ws!.send(
+            JSON.stringify({
+              __isHandshakeMessages: true,
+              pluginName: PLUGIN_NAME,
+              method: "handshake",
+              protocolVersion: 1,
+              browserClientId: this.browserClientId,
+            }),
+          );
+          this.setupMessageHandler();
+          clearTimeout(timeout);
+          this.connected = true;
+          debug("WebSocket connected, waiting for app bridge_ready...");
+          resolve(true);
+        });
+
+        this.ws!.on("error", (err) => {
+          clearTimeout(timeout);
+          debug("WebSocket connection error:", err.message);
+          resolve(false);
+        });
+      });
+    } catch {
+      return false;
+    }
+  }
+
+  get isConnected(): boolean {
+    return this.connected && this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  /**
+   * Wait for the app to signal it's ready (ExpoMCPDevTools mounted).
+   * Resolves immediately if already ready.
+   */
+  waitForReady(): Promise<void> {
+    if (this.ready) return Promise.resolve();
+    return new Promise((resolve) => {
+      this.readyResolvers.push(resolve);
+    });
+  }
+
+  /**
+   * Send a request to the app and wait for the response.
+   */
+  async request<T = any>(
+    type: string,
+    payload?: Record<string, any>,
+    timeoutMs = 5000,
+  ): Promise<T> {
+    if (!this.isConnected) {
+      throw new Error(
+        "Runtime bridge not connected. Is the app running with expo-mcp/runtime?",
+      );
+    }
+
+    const requestId = crypto.randomUUID();
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(
+          new Error(
+            `Runtime request '${type}' timed out after ${timeoutMs}ms`,
+          ),
+        );
+      }, timeoutMs);
+
+      this.pending.set(requestId, { resolve, reject, timeout });
+
+      this.ws!.send(
+        JSON.stringify({
+          messageKey: {
+            pluginName: PLUGIN_NAME,
+            method: type,
+          },
+          payload: {
+            requestId,
+            ...(payload ?? {}),
+          },
+        }),
+      );
+    });
+  }
+
+  async close(): Promise<void> {
+    this.connected = false;
+    this.ready = false;
+    for (const [id, req] of this.pending) {
+      clearTimeout(req.timeout);
+      req.reject(new Error("Connection closed"));
+    }
+    this.pending.clear();
+    this.ws?.close();
+  }
+
+  private setupMessageHandler(): void {
+    this.ws!.on("message", (data) => {
+      try {
+        const raw = data.toString();
+        const msg = JSON.parse(raw);
+
+        // Skip handshake messages
+        if (msg.__isHandshakeMessages) return;
+
+        const messageKey = msg.messageKey;
+        const payload = msg.payload;
+
+        if (!messageKey || messageKey.pluginName !== PLUGIN_NAME) return;
+
+        // App signals it's ready
+        if (messageKey.method === "bridge_ready") {
+          debug("App bridge_ready received");
+          this.ready = true;
+          for (const resolve of this.readyResolvers) {
+            resolve();
+          }
+          this.readyResolvers = [];
+          return;
+        }
+
+        // Response to a pending request
+        if (payload?.requestId && this.pending.has(payload.requestId)) {
+          const req = this.pending.get(payload.requestId)!;
+          clearTimeout(req.timeout);
+          this.pending.delete(payload.requestId);
+
+          if (payload.error) {
+            req.reject(new Error(payload.error));
+          } else {
+            req.resolve(payload.result);
+          }
+        }
+      } catch (err) {
+        debug("Failed to parse runtime message:", err);
+      }
+    });
+
+    this.ws!.on("close", () => {
+      debug("Runtime bridge disconnected");
+      this.connected = false;
+      this.ready = false;
+    });
+  }
+}

--- a/packages/expo-mcp/src/mcp/tools.ts
+++ b/packages/expo-mcp/src/mcp/tools.ts
@@ -4,9 +4,11 @@ import { $, within } from 'zx';
 
 import { AutomationFactory } from '../automation/AutomationFactory.js';
 import { createLogCollector } from '../develop/LogCollectorFactory.js';
+import { RuntimeClient } from '../develop/RuntimeClient.js';
 import { findDevServerUrlAsync, openDevtoolsAsync } from '../develop/devtools.js';
 import { isExpoRouterProject } from '../project.js';
 import { addAutomationTools } from './tools/automation.js';
+import { discoverAndRegisterRuntimeTools } from './tools/runtime.js';
 
 export function addMcpTools(server: McpServerProxy, projectRoot: string) {
   const isRouterProject = isExpoRouterProject(projectRoot);
@@ -141,5 +143,22 @@ export function addMcpTools(server: McpServerProxy, projectRoot: string) {
     }
   );
 
-  addAutomationTools(server, projectRoot);
+  // Runtime bridge — connect to the devtools broadcast WebSocket,
+  // wait for the app to signal ready, then discover and register tools
+  const runtimeClient = new RuntimeClient(server.devServerUrl);
+  runtimeClient.connectAsync().then(async (connected) => {
+    if (!connected) {
+      console.error(
+        '[expo-mcp] Runtime bridge not available — add <ExpoMCPDevTools /> to your layout'
+      );
+      return;
+    }
+    console.error('[expo-mcp] Connected to devtools, waiting for app...');
+    await runtimeClient.waitForReady();
+    console.error('[expo-mcp] App ready — discovering tools...');
+    await discoverAndRegisterRuntimeTools(server, runtimeClient);
+  });
+
+  // Existing automation tools, now with runtime fallback for physical devices
+  addAutomationTools(server, projectRoot, runtimeClient);
 }

--- a/packages/expo-mcp/src/mcp/tools/automation.ts
+++ b/packages/expo-mcp/src/mcp/tools/automation.ts
@@ -5,6 +5,7 @@ import { tmpfile } from 'zx';
 
 import type { IAutomation } from '../../automation/Automation.types.js';
 import { AutomationFactory } from '../../automation/AutomationFactory.js';
+import { RuntimeClient } from '../../develop/RuntimeClient.js';
 import { resizeImageToMaxSizeAsync } from '../../imageUtils.js';
 
 type AutomationContext = {
@@ -25,13 +26,28 @@ async function getAutomationContext(
   return { automation, platform, deviceId, appId };
 }
 
-export function addAutomationTools(server: McpServerProxy, projectRoot: string) {
+function findInTree(elements: any[], testID: string): any | null {
+  for (const el of elements) {
+    if (el.testID === testID) return el;
+    if (el.children) {
+      const found = findInTree(el.children, testID);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+export function addAutomationTools(
+  server: McpServerProxy,
+  projectRoot: string,
+  runtimeClient: RuntimeClient
+) {
   server.registerTool(
     'automation_tap',
     {
       title: 'Tap on device',
       description:
-        'Tap on the device at the given coordinates (x, y) or by react-native testID. Provide either (x AND y) or testID.',
+        'Tap on the device at the given coordinates (x, y) or by react-native testID. Provide either (x AND y) or testID. Works on simulators and physical devices.',
       inputSchema: {
         projectRoot: z.string(),
         platform: z.enum(['android', 'ios']).optional(),
@@ -44,25 +60,33 @@ export function addAutomationTools(server: McpServerProxy, projectRoot: string) 
       },
     },
     async ({ projectRoot, platform, x, y, testID }) => {
-      if (testID) {
-        const { automation } = await getAutomationContext(projectRoot, platform);
-        const result = await automation.tapByTestIDAsync(testID);
-        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
-      } else if (x !== undefined && y !== undefined) {
-        const { automation } = await getAutomationContext(projectRoot, platform);
-        const result = await automation.tapAsync({ x, y });
-        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
-      } else {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: 'Error: Must provide either testID or both x and y coordinates',
-            },
-          ],
-          isError: true,
-        };
+      try {
+        if (testID) {
+          const { automation } = await getAutomationContext(projectRoot, platform);
+          const result = await automation.tapByTestIDAsync(testID);
+          return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+        } else if (x !== undefined && y !== undefined) {
+          const { automation } = await getAutomationContext(projectRoot, platform);
+          const result = await automation.tapAsync({ x, y });
+          return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+        }
+      } catch (simulatorError) {
+        // Fallback: runtime bridge — tap via fiber instance onPress
+        if (runtimeClient.isConnected && testID) {
+          const result = await runtimeClient.request('tap', { testID });
+          return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+        }
+        throw simulatorError;
       }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: 'Error: Must provide either testID or both x and y coordinates',
+          },
+        ],
+        isError: true,
+      };
     }
   );
 
@@ -71,7 +95,7 @@ export function addAutomationTools(server: McpServerProxy, projectRoot: string) 
     {
       title: 'Take screenshot of the app',
       description:
-        'Take screenshot of the full app or a specific view by react-native testID. Optionally provide testID to screenshot a specific view.',
+        'Take screenshot of the full app or a specific view by react-native testID. Works on simulators and physical devices.',
       inputSchema: {
         projectRoot: z.string(),
         platform: z.enum(['android', 'ios']).optional(),
@@ -84,20 +108,35 @@ export function addAutomationTools(server: McpServerProxy, projectRoot: string) 
       },
     },
     async ({ projectRoot, platform, testID }) => {
-      const { automation } = await getAutomationContext(projectRoot, platform);
-      const outputPath = `${tmpfile()}.png`;
+      // Try simulator-based approach first (captures full native UI including status bar)
       try {
-        if (testID) {
-          await automation.taksScreenshotByTestIDAsync({ testID, outputPath });
-        } else {
-          await automation.takeFullScreenshotAsync({ outputPath });
+        const { automation } = await getAutomationContext(projectRoot, platform);
+        const outputPath = `${tmpfile()}.png`;
+        try {
+          if (testID) {
+            await automation.taksScreenshotByTestIDAsync({ testID, outputPath });
+          } else {
+            await automation.takeFullScreenshotAsync({ outputPath });
+          }
+          const { buffer } = await resizeImageToMaxSizeAsync(outputPath);
+          return {
+            content: [{ type: 'image', data: buffer.toString('base64'), mimeType: 'image/jpeg' }],
+          };
+        } finally {
+          await fs.promises.rm(outputPath, { force: true });
         }
-        const { buffer } = await resizeImageToMaxSizeAsync(outputPath);
-        return {
-          content: [{ type: 'image', data: buffer.toString('base64'), mimeType: 'image/jpeg' }],
-        };
-      } finally {
-        await fs.promises.rm(outputPath, { force: true });
+      } catch (simulatorError) {
+        // Fallback: runtime bridge (works on physical devices)
+        if (runtimeClient.isConnected) {
+          const result = await runtimeClient.request('take_screenshot', { testID });
+          return {
+            content: [{ type: 'image', data: result.base64, mimeType: 'image/png' }],
+          };
+        }
+        throw new Error(
+          `Screenshot failed: simulator not available (${simulatorError}), ` +
+            `and runtime bridge not connected. Add <ExpoMCPDevTools /> to your layout.`
+        );
       }
     }
   );
@@ -107,7 +146,7 @@ export function addAutomationTools(server: McpServerProxy, projectRoot: string) 
     {
       title: 'Find view properties',
       description:
-        'Find view and dump its properties. This is useful to verify the view is rendered correctly',
+        'Find view and dump its properties. Works on simulators and physical devices.',
       inputSchema: {
         projectRoot: z.string(),
         platform: z.enum(['android', 'ios']).optional(),
@@ -115,9 +154,24 @@ export function addAutomationTools(server: McpServerProxy, projectRoot: string) 
       },
     },
     async ({ projectRoot, platform, testID }) => {
-      const { automation } = await getAutomationContext(projectRoot, platform);
-      const result = await automation.findViewByTestIDAsync(testID);
-      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      // Try simulator first
+      try {
+        const { automation } = await getAutomationContext(projectRoot, platform);
+        const result = await automation.findViewByTestIDAsync(testID);
+        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      } catch (simulatorError) {
+        // Fallback: runtime bridge — search fiber tree
+        if (runtimeClient.isConnected) {
+          const tree = await runtimeClient.request('get_tree');
+          const found = findInTree(tree.elements, testID);
+          if (found) {
+            return {
+              content: [{ type: 'text', text: JSON.stringify({ success: true, data: found }) }],
+            };
+          }
+        }
+        throw simulatorError;
+      }
     }
   );
 }

--- a/packages/expo-mcp/src/mcp/tools/runtime.ts
+++ b/packages/expo-mcp/src/mcp/tools/runtime.ts
@@ -1,0 +1,129 @@
+import { type McpServerProxy } from "@expo/mcp-tunnel";
+import { z } from "zod";
+
+import { RuntimeClient } from "../../develop/RuntimeClient.js";
+
+// Mirrors HandlerInfo from runtime/bridge.ts (wire protocol type).
+// Can't import directly since runtime/ is React Native code excluded from the server build.
+interface HandlerInfo {
+  messageType: string;
+  source: string;
+  title?: string;
+  description?: string;
+  inputSchema?: Record<string, any>;
+}
+
+/**
+ * Discover handlers registered on the runtime bridge and dynamically
+ * create MCP tools for each one. This means any package that registers
+ * handlers on the bridge (expo-mcp builtins, expo-semantic-ai, etc.)
+ * automatically gets corresponding MCP tools — no hardcoding needed.
+ *
+ * Waits for the app to send a "bridge_ready" message before discovering,
+ * so there's no race condition with component mounting.
+ */
+export async function discoverAndRegisterRuntimeTools(
+  server: McpServerProxy,
+  runtimeClient: RuntimeClient,
+): Promise<void> {
+  if (!runtimeClient.isConnected) return;
+
+  // Wait for the app to signal it's ready
+  await runtimeClient.waitForReady();
+
+  try {
+    const { handlers } = await runtimeClient.request<{
+      handlers: HandlerInfo[];
+    }>("get_registered_handlers");
+
+    for (const handler of handlers) {
+      const toolName = `runtime:${handler.source}:${handler.messageType}`;
+      const inputSchema = jsonSchemaToZod(handler.inputSchema);
+
+      server.registerTool(
+        toolName,
+        {
+          title: handler.title ?? handler.messageType,
+          description:
+            handler.description ??
+            `Runtime bridge handler: ${handler.messageType} (from ${handler.source})`,
+          inputSchema,
+        },
+        async (params) => {
+          const result = await runtimeClient.request(
+            handler.messageType,
+            params,
+          );
+          return {
+            content: [
+              { type: "text", text: JSON.stringify(result, null, 2) },
+            ],
+          };
+        },
+      );
+    }
+
+    console.error(
+      `[expo-mcp] Registered ${handlers.length} runtime tools from bridge`,
+    );
+
+    // Notify clients that new tools are available so they re-fetch tools/list
+    server.sendToolListChanged();
+  } catch (err: any) {
+    console.error(
+      "[expo-mcp] Failed to discover runtime handlers:",
+      err.message,
+    );
+  }
+}
+
+/**
+ * Convert a JSON Schema object to a Zod schema shape for MCP tool registration.
+ */
+function jsonSchemaToZod(
+  schema?: Record<string, any>,
+): Record<string, z.ZodTypeAny> | undefined {
+  if (!schema?.properties) return undefined;
+
+  const shape: Record<string, z.ZodTypeAny> = {};
+  const required = new Set<string>(schema.required ?? []);
+
+  for (const [key, prop] of Object.entries<any>(schema.properties)) {
+    let field: z.ZodTypeAny;
+
+    switch (prop.type) {
+      case "number":
+        field = z.number();
+        break;
+      case "boolean":
+        field = z.boolean();
+        break;
+      case "object":
+        field = z.record(z.any());
+        break;
+      case "array":
+        field = z.array(z.any());
+        break;
+      case "string":
+      default:
+        if (prop.enum) {
+          field = z.enum(prop.enum as [string, ...string[]]);
+        } else {
+          field = z.string();
+        }
+        break;
+    }
+
+    if (prop.description) {
+      field = field.describe(prop.description);
+    }
+
+    if (!required.has(key)) {
+      field = field.optional();
+    }
+
+    shape[key] = field;
+  }
+
+  return shape;
+}

--- a/packages/expo-mcp/src/runtime/bridge.ts
+++ b/packages/expo-mcp/src/runtime/bridge.ts
@@ -1,0 +1,154 @@
+/**
+ * The MCP runtime bridge plugin system.
+ *
+ * Any package can register message handlers that will be routed through
+ * the ExpoMCPDevTools WebSocket bridge. This allows packages like
+ * expo-semantic-ai to extend the MCP server's capabilities from inside
+ * the running app without expo-mcp needing to know about them.
+ *
+ * Handlers include metadata (title, description, inputSchema as JSON Schema)
+ * so the server side can dynamically register corresponding MCP tools.
+ *
+ * Usage from any package:
+ *
+ *   const bridge = globalThis.__EXPO_MCP_BRIDGE__;
+ *   bridge.registerHandler({
+ *     messageType: "get_actions",
+ *     title: "Get available actions",
+ *     description: "List all AI actions on the current screen",
+ *     handler: async () => registry.getActions(),
+ *   }, "my-package");
+ */
+
+export type MessageHandler = (payload: any) => any | Promise<any>;
+
+export interface HandlerConfig {
+  messageType: string;
+  handler: MessageHandler;
+  /** Title shown in MCP tool listing */
+  title?: string;
+  /** Description shown in MCP tool listing */
+  description?: string;
+  /** JSON Schema for the handler's input parameters */
+  inputSchema?: Record<string, any>;
+}
+
+interface RegisteredHandler extends HandlerConfig {
+  source: string;
+}
+
+export interface HandlerInfo {
+  messageType: string;
+  source: string;
+  title?: string;
+  description?: string;
+  inputSchema?: Record<string, any>;
+}
+
+class MCPBridge {
+  private handlers = new Map<string, RegisteredHandler>();
+  private listeners = new Set<() => void>();
+
+  /**
+   * Register a handler with metadata for MCP tool discovery.
+   * Returns an unregister function.
+   */
+  registerHandler(
+    config: HandlerConfig,
+    source = "unknown",
+  ): () => void {
+    const { messageType } = config;
+
+    if (this.handlers.has(messageType)) {
+      const existing = this.handlers.get(messageType)!;
+      console.warn(
+        `[expo-mcp] Handler for '${messageType}' replaced (was: ${existing.source}, now: ${source})`,
+      );
+    }
+
+    this.handlers.set(messageType, { ...config, source });
+    this.notifyListeners();
+
+    return () => {
+      const current = this.handlers.get(messageType);
+      if (current?.handler === config.handler) {
+        this.handlers.delete(messageType);
+        this.notifyListeners();
+      }
+    };
+  }
+
+  /**
+   * Register multiple handlers at once.
+   * Returns a single unregister function that removes all of them.
+   */
+  registerHandlers(
+    handlers: HandlerConfig[],
+    source = "unknown",
+  ): () => void {
+    const unregisters = handlers.map((config) =>
+      this.registerHandler(config, source),
+    );
+
+    return () => {
+      for (const unregister of unregisters) {
+        unregister();
+      }
+    };
+  }
+
+  /**
+   * Get the handler function for a message type.
+   * Used internally by ExpoMCPDevTools to route messages.
+   */
+  getHandler(messageType: string): MessageHandler | undefined {
+    return this.handlers.get(messageType)?.handler;
+  }
+
+  /**
+   * Get all registered message types.
+   * Used internally by ExpoMCPDevTools to set up listeners.
+   */
+  getMessageTypes(): string[] {
+    return [...this.handlers.keys()];
+  }
+
+  /**
+   * Get metadata for all registered handlers.
+   * Used by the server side to dynamically create MCP tools.
+   */
+  getHandlerInfos(): HandlerInfo[] {
+    return [...this.handlers.values()].map(
+      ({ messageType, source, title, description, inputSchema }) => ({
+        messageType,
+        source,
+        title,
+        description,
+        inputSchema,
+      }),
+    );
+  }
+
+  /**
+   * Subscribe to handler registration changes.
+   * ExpoMCPDevTools uses this to re-subscribe when new handlers are added.
+   */
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private notifyListeners(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+// Singleton on a global so external packages can find the bridge
+// without needing to resolve expo-mcp/runtime as a module import.
+// Same pattern as __REACT_DEVTOOLS_GLOBAL_HOOK__.
+const GLOBAL_KEY = "__EXPO_MCP_BRIDGE__";
+
+export const mcpBridge: MCPBridge =
+  (globalThis as any)[GLOBAL_KEY] ?? ((globalThis as any)[GLOBAL_KEY] = new MCPBridge());

--- a/packages/expo-mcp/src/runtime/builtins.ts
+++ b/packages/expo-mcp/src/runtime/builtins.ts
@@ -1,0 +1,148 @@
+/**
+ * Built-in handlers for expo-mcp runtime bridge.
+ * These are registered via the same mcpBridge plugin system that
+ * external packages use — expo-mcp eats its own dog food.
+ *
+ * Only includes transport-level capabilities (tree, interaction, routing, dev tools).
+ * Semantic features (actions, state) are intentionally left to plugins
+ * like expo-semantic-ai to keep expo-mcp unopinionated.
+ */
+import { mcpBridge } from "./bridge";
+import { DevSettings } from "react-native";
+import { getAccessibilityTree } from "./tree";
+import { typeText, scroll, takeScreenshot } from "./interaction";
+import { getScreen, getRoutes, navigate } from "./router";
+
+const SOURCE = "expo-mcp";
+
+export function registerBuiltinHandlers(): () => void {
+  return mcpBridge.registerHandlers(
+    [
+      {
+        messageType: "get_tree",
+        title: "Get accessibility tree",
+        description:
+          "Get the accessibility tree of the currently visible screen. Returns element IDs, roles, labels, bounds, testIDs.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            maxDepth: {
+              type: "number",
+              description: "Max tree depth (default: unlimited)",
+            },
+          },
+        },
+        handler: (p) => getAccessibilityTree(p),
+      },
+      {
+        messageType: "get_screen",
+        title: "Get current screen info",
+        description:
+          "Get current route, params, and navigation stack from expo-router",
+        handler: () => getScreen(),
+      },
+      {
+        messageType: "get_routes",
+        title: "Get full route tree",
+        description:
+          "Get the complete expo-router route tree with available screens",
+        handler: () => getRoutes(),
+      },
+      {
+        messageType: "type_text",
+        title: "Type text into a field",
+        description:
+          "Focus a text input by testID and type text into it",
+        inputSchema: {
+          type: "object",
+          properties: {
+            testID: { type: "string", description: "React Native testID" },
+            text: { type: "string", description: "Text to type" },
+            clear: {
+              type: "boolean",
+              description: "Clear existing text first (default: false)",
+            },
+            submit: {
+              type: "boolean",
+              description: "Press return/submit after typing (default: false)",
+            },
+          },
+          required: ["text"],
+        },
+        handler: (p) => typeText(p),
+      },
+      {
+        messageType: "scroll",
+        title: "Scroll a container",
+        description: "Scroll a ScrollView/FlatList by testID",
+        inputSchema: {
+          type: "object",
+          properties: {
+            testID: { type: "string", description: "React Native testID" },
+            direction: {
+              type: "string",
+              enum: ["up", "down", "left", "right"],
+              description: "Scroll direction",
+            },
+            amount: {
+              type: "number",
+              description: "Pixels to scroll (default: 500)",
+            },
+            toEnd: {
+              type: "boolean",
+              description: "Scroll to end (default: false)",
+            },
+          },
+          required: ["direction"],
+        },
+        handler: (p) => scroll(p),
+      },
+      {
+        messageType: "navigate",
+        title: "Navigate to a route",
+        description: "Navigate to an expo-router route",
+        inputSchema: {
+          type: "object",
+          properties: {
+            route: {
+              type: "string",
+              description: "Route path (e.g. /products/abc-123)",
+            },
+            params: {
+              type: "object",
+              description: "Route params",
+            },
+          },
+          required: ["route"],
+        },
+        handler: (p) => navigate(p),
+      },
+      {
+        messageType: "take_screenshot",
+        title: "Take screenshot",
+        description:
+          "Capture a screenshot from inside the app. Works on physical devices.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            testID: {
+              type: "string",
+              description: "testID of specific view to capture (omit for full screen)",
+            },
+          },
+        },
+        handler: (p) => takeScreenshot(p),
+      },
+      {
+        messageType: "reload",
+        title: "Reload the app",
+        description: "Trigger a full reload of the running app",
+        handler: () => {
+          DevSettings.reload();
+          return { success: true };
+        },
+      },
+    ],
+    SOURCE,
+  );
+}

--- a/packages/expo-mcp/src/runtime/components/ExpoMCPDevTools.tsx
+++ b/packages/expo-mcp/src/runtime/components/ExpoMCPDevTools.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, createContext, useRef, useState } from "react";
+import {
+  useDevToolsPluginClient,
+  type EventSubscription,
+} from "expo/devtools";
+import { mcpBridge } from "../bridge";
+import { registerBuiltinHandlers } from "../builtins";
+
+const PLUGIN_NAME = "expo-mcp-runtime";
+
+/**
+ * Context that lets child hooks know the bridge is active.
+ * In production builds, this component renders null and the context
+ * is never provided, so hooks no-op automatically.
+ */
+export const MCPBridgeContext = createContext<{ active: boolean }>({
+  active: false,
+});
+
+export function ExpoMCPDevTools({ children }: { children?: React.ReactNode }) {
+  if (!__DEV__) return <>{children}</>;
+  return (
+    <MCPBridgeContext.Provider value={{ active: true }}>
+      <BuiltinRegistration />
+      <RuntimeBridge />
+      {children}
+    </MCPBridgeContext.Provider>
+  );
+}
+
+/**
+ * Registers expo-mcp's built-in handlers (tree, interaction, router)
+ * via the bridge plugin system — same mechanism external packages use.
+ */
+function BuiltinRegistration() {
+  useEffect(() => {
+    return registerBuiltinHandlers();
+  }, []);
+
+  return null;
+}
+
+/**
+ * Connects to the devtools plugin WebSocket and routes all messages
+ * through the mcpBridge handler registry.
+ *
+ * Handlers are looked up at call time (not capture time) so that
+ * when a plugin replaces a handler, the new one is used immediately
+ * without needing to re-subscribe.
+ */
+function RuntimeBridge() {
+  const client = useDevToolsPluginClient(PLUGIN_NAME);
+  const subscriptionsRef = useRef<EventSubscription[]>([]);
+  const [version, setVersion] = useState(0);
+
+  // Re-render when handlers change so we can re-subscribe
+  useEffect(() => {
+    return mcpBridge.subscribe(() => setVersion((v) => v + 1));
+  }, []);
+
+  useEffect(() => {
+    if (!client) return;
+
+    // Clean up previous subscriptions
+    for (const sub of subscriptionsRef.current) {
+      sub?.remove();
+    }
+    subscriptionsRef.current = [];
+
+    const handlerTypes = mcpBridge.getMessageTypes();
+    console.log(
+      `[expo-mcp] Runtime bridge connected (${handlerTypes.length} handlers)`,
+    );
+
+    // Meta-handler: lets the server discover registered handlers and their metadata
+    const metaSub = client.addMessageListener(
+      "get_registered_handlers",
+      async (data: any) => {
+        const requestId = data?.requestId;
+        client.sendMessage("response", {
+          requestId,
+          result: { handlers: mcpBridge.getHandlerInfos() },
+        });
+      },
+    );
+    subscriptionsRef.current.push(metaSub);
+
+    for (const messageType of handlerTypes) {
+      // Capture messageType but look up handler at call time
+      const type = messageType;
+      const sub = client.addMessageListener(
+        type,
+        async (data: any) => {
+          const requestId = data?.requestId;
+          const handler = mcpBridge.getHandler(type);
+          if (!handler) {
+            client.sendMessage("response", {
+              requestId,
+              error: `No handler registered for '${type}'`,
+            });
+            return;
+          }
+          try {
+            const result = await handler(data ?? {});
+            client.sendMessage("response", { requestId, result });
+          } catch (error: any) {
+            console.warn(
+              `[expo-mcp] Handler error for '${type}':`,
+              error.message,
+            );
+            client.sendMessage("response", {
+              requestId,
+              error: error.message ?? String(error),
+            });
+          }
+        },
+      );
+      subscriptionsRef.current.push(sub);
+    }
+
+    // Signal to the server that all handlers are registered and ready
+    client.sendMessage("bridge_ready", {});
+
+    return () => {
+      for (const sub of subscriptionsRef.current) {
+        sub?.remove();
+      }
+      subscriptionsRef.current = [];
+    };
+  }, [client, version]);
+
+  return null;
+}

--- a/packages/expo-mcp/src/runtime/index.ts
+++ b/packages/expo-mcp/src/runtime/index.ts
@@ -1,0 +1,3 @@
+export { ExpoMCPDevTools } from "./components/ExpoMCPDevTools";
+export { mcpBridge } from "./bridge";
+export type { MessageHandler } from "./bridge";

--- a/packages/expo-mcp/src/runtime/interaction.ts
+++ b/packages/expo-mcp/src/runtime/interaction.ts
@@ -1,0 +1,168 @@
+import { findNodeHandle, PixelRatio } from "react-native";
+
+/**
+ * Find an element by testID or elementId in the React fiber tree,
+ * then return its native host instance.
+ */
+function findHostInstance(identifier: {
+  elementId?: string;
+  testID?: string;
+}): any {
+  const hook = (globalThis as any).__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!hook) throw new Error("React DevTools hook not available");
+
+  for (const [, renderer] of hook.renderers) {
+    const roots = hook.getFiberRoots?.(renderer) ?? new Set();
+    for (const root of roots) {
+      const found = searchFiber(root.current, identifier);
+      if (found) return found;
+    }
+  }
+  throw new Error(`Element not found: ${JSON.stringify(identifier)}`);
+}
+
+function searchFiber(
+  fiber: any,
+  identifier: { elementId?: string; testID?: string },
+): any {
+  if (!fiber) return null;
+
+  const props = fiber.memoizedProps;
+  if (props && identifier.testID && props.testID === identifier.testID) {
+    return fiber.stateNode;
+  }
+
+  let result = searchFiber(fiber.child, identifier);
+  if (result) return result;
+
+  result = searchFiber(fiber.sibling, identifier);
+  return result;
+}
+
+/**
+ * Find the root host instance (the top-level native view) for full-screen capture.
+ */
+function findRootHostInstance(): any {
+  const hook = (globalThis as any).__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!hook) throw new Error("React DevTools hook not available");
+
+  for (const [, renderer] of hook.renderers) {
+    const roots = hook.getFiberRoots?.(renderer) ?? new Set();
+    for (const root of roots) {
+      let fiber = root.current;
+      while (fiber) {
+        if (fiber.stateNode && typeof fiber.stateNode.measure === "function") {
+          return fiber.stateNode;
+        }
+        fiber = fiber.child;
+      }
+    }
+  }
+  throw new Error("No root host instance found");
+}
+
+export async function typeText(params: {
+  elementId?: string;
+  testID?: string;
+  text: string;
+  clear?: boolean;
+  submit?: boolean;
+}): Promise<{ success: boolean }> {
+  const instance = findHostInstance(params);
+  if (!instance) {
+    return { success: false };
+  }
+
+  if (typeof instance.focus === "function") {
+    instance.focus();
+  }
+
+  if (params.clear) {
+    if (instance.props?.onChangeText) {
+      instance.props.onChangeText("");
+    }
+  }
+
+  if (instance.props?.onChangeText) {
+    instance.props.onChangeText(
+      params.clear ? params.text : (instance.props.value ?? "") + params.text,
+    );
+  }
+
+  if (params.submit && instance.props?.onSubmitEditing) {
+    instance.props.onSubmitEditing({ nativeEvent: { text: params.text } });
+  }
+
+  return { success: true };
+}
+
+export async function scroll(params: {
+  elementId?: string;
+  testID?: string;
+  direction: "up" | "down" | "left" | "right";
+  amount?: number;
+  toEnd?: boolean;
+}): Promise<{ success: boolean }> {
+  const instance = findHostInstance(params);
+  if (!instance) {
+    return { success: false };
+  }
+
+  const amount = params.amount ?? 500;
+
+  if (params.toEnd && typeof instance.scrollToEnd === "function") {
+    instance.scrollToEnd({ animated: false });
+  } else if (typeof instance.scrollTo === "function") {
+    const offsets: Record<string, { x: number; y: number }> = {
+      up: { x: 0, y: -amount },
+      down: { x: 0, y: amount },
+      left: { x: -amount, y: 0 },
+      right: { x: amount, y: 0 },
+    };
+    instance.scrollTo({ ...offsets[params.direction], animated: false });
+  }
+
+  return { success: true };
+}
+
+/**
+ * Capture a screenshot from inside the app using react-native-view-shot.
+ * Works on physical devices — key advantage over xcodebuild/adb.
+ */
+export async function takeScreenshot(params: {
+  testID?: string;
+}): Promise<{ base64: string; width: number; height: number }> {
+  try {
+    const { captureRef: capture } = require("react-native-view-shot");
+
+    let ref: any;
+    if (params.testID) {
+      ref = findHostInstance({ testID: params.testID });
+    } else {
+      ref = findRootHostInstance();
+    }
+
+    const nodeHandle = findNodeHandle(ref);
+    if (!nodeHandle) throw new Error("Could not get native handle");
+
+    const uri = await capture(nodeHandle, {
+      format: "png",
+      quality: 0.8,
+      result: "base64",
+    });
+
+    return new Promise((resolve, reject) => {
+      ref.measure((x: number, y: number, width: number, height: number) => {
+        resolve({
+          base64: uri,
+          width: Math.round(width * PixelRatio.get()),
+          height: Math.round(height * PixelRatio.get()),
+        });
+      });
+    });
+  } catch (err: any) {
+    throw new Error(
+      `Screenshot failed: ${err.message}. Install react-native-view-shot for in-app screenshots.`,
+    );
+  }
+}

--- a/packages/expo-mcp/src/runtime/router.ts
+++ b/packages/expo-mcp/src/runtime/router.ts
@@ -1,0 +1,131 @@
+/**
+ * Get the current screen from expo-router.
+ * Uses the router store directly — no hooks, safe to call outside React.
+ */
+export function getScreen(): {
+  route: string;
+  params: Record<string, any>;
+  segments: string[];
+  navigationStack: string[];
+} {
+  try {
+    const store = getStore();
+    if (!store) return defaultScreen();
+
+    const routeInfo = store.getRouteInfo();
+    const state = store.state;
+
+    return {
+      route: routeInfo?.pathname ?? "/",
+      params: routeInfo?.params ?? {},
+      segments: routeInfo?.segments ?? [],
+      navigationStack: state ? extractStack(state) : ["/"],
+    };
+  } catch (e) {
+    console.warn("[expo-mcp] getScreen error:", e);
+    return defaultScreen();
+  }
+}
+
+/**
+ * Get the full route tree from expo-router.
+ */
+export function getRoutes(): {
+  routes: Array<{ path: string; screenName: string }>;
+  currentRoute: string;
+} {
+  try {
+    const store = getStore();
+    if (!store) return { routes: [], currentRoute: getScreen().route };
+
+    const routeNode = store.routeNode;
+    if (routeNode) {
+      return {
+        routes: collectRoutes(routeNode),
+        currentRoute: getScreen().route,
+      };
+    }
+
+    return { routes: [], currentRoute: getScreen().route };
+  } catch (e) {
+    console.warn("[expo-mcp] getRoutes error:", e);
+    return { routes: [], currentRoute: "/" };
+  }
+}
+
+/**
+ * Navigate to a route using expo-router.
+ */
+export async function navigate(params: {
+  route: string;
+  params?: Record<string, any>;
+}): Promise<{ success: boolean; currentRoute?: string }> {
+  try {
+    const { router } = require("expo-router");
+    if (params.params) {
+      router.push({ pathname: params.route, params: params.params });
+    } else {
+      router.push(params.route);
+    }
+    return { success: true };
+  } catch (error: any) {
+    console.warn("[expo-mcp] navigate error:", error);
+    return { success: false };
+  }
+}
+
+function defaultScreen() {
+  return {
+    route: "/",
+    params: {},
+    segments: [] as string[],
+    navigationStack: ["/"],
+  };
+}
+
+// expo-router doesn't expose a public imperative API to read current route state
+// outside of React hooks. We access the internal store directly — wrapped in
+// try/catch since this internal path may change across expo-router versions.
+function getStore(): any {
+  try {
+    return require("expo-router/build/global-state/router-store").store;
+  } catch (e) {
+    console.warn("[expo-mcp] Could not load router store:", e);
+    return null;
+  }
+}
+
+function collectRoutes(
+  node: any,
+  prefix = "",
+): Array<{ path: string; screenName: string }> {
+  const routes: Array<{ path: string; screenName: string }> = [];
+
+  const path = prefix + (node.route ? `/${node.route}` : "");
+
+  if (node.route && !node.route.startsWith("_")) {
+    routes.push({
+      path: path || "/",
+      screenName: node.route,
+    });
+  }
+
+  if (node.children) {
+    for (const child of node.children) {
+      routes.push(...collectRoutes(child, path));
+    }
+  }
+
+  return routes;
+}
+
+function extractStack(state: any, prefix = ""): string[] {
+  if (!state?.routes) return [];
+  return state.routes
+    .map((r: any) => {
+      const path = `${prefix}/${r.name}`;
+      if (r.state) return extractStack(r.state, path);
+      return [path];
+    })
+    .flat();
+}

--- a/packages/expo-mcp/src/runtime/tree.ts
+++ b/packages/expo-mcp/src/runtime/tree.ts
@@ -1,0 +1,111 @@
+interface TreeElement {
+  id: string;
+  role?: string;
+  label?: string;
+  testID?: string;
+  value?: string;
+  bounds?: { x: number; y: number; width: number; height: number };
+  children?: TreeElement[];
+}
+
+let elementCounter = 0;
+
+/**
+ * Get the accessibility tree of the currently visible screen.
+ *
+ * Walks the React fiber tree via __REACT_DEVTOOLS_GLOBAL_HOOK__ to extract
+ * accessibility roles, labels, testIDs, and bounds.
+ */
+export async function getAccessibilityTree(
+  options?: { maxDepth?: number },
+): Promise<{ elements: TreeElement[] }> {
+  const hook = (globalThis as any).__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!hook || !hook.renderers) {
+    return { elements: [] };
+  }
+
+  elementCounter = 0;
+  const elements: TreeElement[] = [];
+
+  for (const [, renderer] of hook.renderers) {
+    const roots = hook.getFiberRoots?.(renderer) ?? new Set();
+    for (const root of roots) {
+      const fiber = root.current;
+      if (fiber?.child) {
+        walkFiber(fiber.child, elements, 0, options?.maxDepth ?? 50);
+      }
+    }
+  }
+
+  return { elements };
+}
+
+function walkFiber(
+  fiber: any,
+  elements: TreeElement[],
+  depth: number,
+  maxDepth: number,
+): void {
+  if (!fiber || depth > maxDepth) return;
+
+  const props = fiber.memoizedProps;
+  if (props && typeof props === "object") {
+    const hasA11y =
+      props.accessible ||
+      props.accessibilityRole ||
+      props.accessibilityLabel ||
+      props.testID ||
+      props["aria-label"] ||
+      props.role;
+
+    if (hasA11y) {
+      const element: TreeElement = {
+        id: `e${++elementCounter}`,
+        role: props.accessibilityRole || props.role,
+        label: props.accessibilityLabel || props["aria-label"],
+        testID: props.testID,
+        value: props.accessibilityValue?.text || props.value,
+      };
+
+      const stateNode = fiber.stateNode;
+      if (stateNode && typeof stateNode.measure === "function") {
+        try {
+          stateNode.measure(
+            (
+              x: number,
+              y: number,
+              width: number,
+              height: number,
+              pageX: number,
+              pageY: number,
+            ) => {
+              element.bounds = { x: pageX, y: pageY, width, height };
+            },
+          );
+        } catch {}
+      }
+
+      const children: TreeElement[] = [];
+      if (fiber.child) {
+        walkFiber(fiber.child, children, depth + 1, maxDepth);
+      }
+      if (children.length > 0) {
+        element.children = children;
+      }
+
+      elements.push(element);
+    } else {
+      if (fiber.child) {
+        walkFiber(fiber.child, elements, depth, maxDepth);
+      }
+    }
+  } else {
+    if (fiber.child) {
+      walkFiber(fiber.child, elements, depth, maxDepth);
+    }
+  }
+
+  if (fiber.sibling) {
+    walkFiber(fiber.sibling, elements, depth, maxDepth);
+  }
+}

--- a/packages/expo-mcp/tsconfig.build.json
+++ b/packages/expo-mcp/tsconfig.build.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "noEmit": false
   },
-  "exclude": ["node_modules", "dist", "src/**/__tests__/*"]
+  "exclude": ["node_modules", "dist", "src/**/__tests__/*", "src/runtime/**/*"]
 }

--- a/packages/mcp-tunnel/src/CompositeMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/CompositeMcpServerProxy.ts
@@ -55,6 +55,11 @@ export class CompositeMcpServerProxy implements McpServerProxy {
     this.tunnelProxy.registerResource(name, uriOrTemplate, config, readCallback);
   };
 
+  sendToolListChanged(): void {
+    this.stdioProxy.sendToolListChanged();
+    this.tunnelProxy.sendToolListChanged();
+  }
+
   async start(): Promise<void> {
     await Promise.all([this.stdioProxy.start(), this.tunnelProxy.start()]);
   }

--- a/packages/mcp-tunnel/src/StdioMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/StdioMcpServerProxy.ts
@@ -62,6 +62,10 @@ export class StdioMcpServerProxy implements McpServerProxy {
     }
   };
 
+  sendToolListChanged(): void {
+    this.server.sendToolListChanged();
+  }
+
   start(): Promise<void> {
     return this.server.connect(this.transport);
   }

--- a/packages/mcp-tunnel/src/TunnelMcpServerProxy.ts
+++ b/packages/mcp-tunnel/src/TunnelMcpServerProxy.ts
@@ -63,6 +63,10 @@ export class TunnelMcpServerProxy implements McpServerProxy {
     };
   }
 
+  sendToolListChanged(): void {
+    // Tunnel clients discover tools through their own registration mechanism
+  }
+
   async start(): Promise<void> {
     await this.transport.start();
   }

--- a/packages/mcp-tunnel/src/types.ts
+++ b/packages/mcp-tunnel/src/types.ts
@@ -67,6 +67,12 @@ export interface McpServerProxy {
   ): void;
 
   /**
+   * Notifies connected clients that the tool list has changed,
+   * prompting them to re-fetch via tools/list.
+   */
+  sendToolListChanged(): void;
+
+  /**
    * Starts the MCP server proxy.
    */
   start(): Promise<void>;


### PR DESCRIPTION
## Summary

Adds an in-app runtime bridge that connects to the running React Native app via Expo's devtools plugin WebSocket. This gives the MCP server deep access to the app alongside the existing simulator-based automation.

**Built-in capabilities:**
- Accessibility tree extraction (fiber tree walking)
- Text input, scrolling, navigation (expo-router)
- Screenshots from inside the app (physical device support)
- App reload via DevSettings

**Pluggable handler system:**
- Any package can register message handlers on the bridge with metadata (title, description, JSON Schema)
- The server side dynamically discovers handlers and creates corresponding MCP tools at runtime
- `tools/list_changed` notification tells clients to re-fetch when new tools appear
- Handlers are registered via `globalThis.__EXPO_MCP_BRIDGE__` — no import dependency on expo-mcp needed

**Developer setup — one line in the root layout:**
```tsx
import { ExpoMCPDevTools } from "expo-mcp/runtime";

export default function RootLayout() {
  return (
    <ExpoMCPDevTools>
      <Stack />
    </ExpoMCPDevTools>
  );
}
```

**How plugins work:**

The bridge is deliberately unopinionated — semantic features like AI actions and state are not built in. Instead, external packages register their own handlers. Example: [`expo-semantic-ai`](https://github.com/kbrandwijk/expo-semantic-ai) ([npm](https://www.npmjs.com/package/expo-semantic-ai)) registers `get_actions`, `get_state`, and `invoke_action` handlers, which the server automatically discovers and exposes as MCP tools.

```tsx
// In the app — expo-semantic-ai registers via the global bridge
import { useSemanticAI, useAIAction } from "expo-semantic-ai";

function RootLayout() {
  useSemanticAI(); // registers handlers on __EXPO_MCP_BRIDGE__
  return <ExpoMCPDevTools><Stack /></ExpoMCPDevTools>;
}

function ProductDetail() {
  useAIAction({
    id: "add-to-cart",
    description: "Add product to cart",
    params: z.object({ quantity: z.number() }),
    handler: ({ quantity }) => addToCart(quantity),
  });
}
```

Claude can then ask: *"What actions are available?"* → *"Invoke add-to-cart with quantity 2"*

**Architecture:**

```
App (React Native)                    Server (Node.js)
┌──────────────────────┐              ┌──────────────────────┐
│ ExpoMCPDevTools      │              │ RuntimeClient        │
│  ├─ builtins         │◄── WS ──────│  ├─ connectAsync()   │
│  ├─ bridge_ready ───►│   broadcast  │  ├─ waitForReady()   │
│  └─ plugin handlers  │              │  └─ request()        │
│                      │              │                      │
│ __EXPO_MCP_BRIDGE__  │              │ discoverAndRegister  │
│  ├─ expo-mcp handlers│              │  ├─ get_registered   │
│  └─ plugin handlers  │              │  ├─ jsonSchema→Zod   │
│     (expo-semantic-ai│              │  └─ server.register  │
│      or any package) │              │     Tool() for each  │
└──────────────────────┘              └──────────────────────┘
```

## Changes

**New files:**
- `src/runtime/` — app-side module (ExpoMCPDevTools, bridge plugin system, builtins)
- `src/develop/RuntimeClient.ts` — server-side WebSocket client with handshake, ready signal, request/response
- `src/mcp/tools/runtime.ts` — dynamic MCP tool discovery and registration from bridge

**Modified:**
- `src/mcp/tools.ts` — wires RuntimeClient connection and tool discovery
- `src/mcp/tools/automation.ts` — adds runtime bridge as fallback for physical devices
- `mcp-tunnel` types + proxies — adds `sendToolListChanged()` to `McpServerProxy`

## Test plan

- [ ] Start app with `EXPO_UNSTABLE_MCP_SERVER=1 bunx expo start`
- [ ] Verify runtime bridge connects and discovers tools
- [ ] Test built-in tools: `runtime:expo-mcp:get_tree`, `runtime:expo-mcp:navigate`, `runtime:expo-mcp:reload`
- [ ] Install `expo-semantic-ai`, verify plugin tools appear: `runtime:expo-semantic-ai:get_actions`, `runtime:expo-semantic-ai:invoke_action`
- [ ] Test on physical device (runtime bridge works over WiFi/USB)
- [ ] Verify production builds have zero runtime overhead (`__DEV__` guard)