### PR TITLE
Add npm bugs metadata

### DIFF
--- a/packages/expo-mcp/package.json
+++ b/packages/expo-mcp/package.json
@@ -19,6 +19,9 @@
     "url": "https://github.com/expo/expo-mcp.git",
     "directory": "packages/expo-mcp"
   },
+  "bugs": {
+    "url": "https://github.com/expo/expo-mcp/issues"
+  },
   "keywords": [
     "expo",
     "MCP",

--- a/packages/mcp-tunnel/package.json
+++ b/packages/mcp-tunnel/package.json
@@ -15,6 +15,9 @@
     "url": "https://github.com/expo/expo-mcp.git",
     "directory": "packages/mcp-tunnel"
   },
+  "bugs": {
+    "url": "https://github.com/expo/expo-mcp/issues"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## What changed

Adds standard npm `bugs.url` metadata to both published packages in this repo:

- `expo-mcp`
- `@expo/mcp-tunnel`

## Why

The published `0.2.4` packages currently expose `repository` metadata, but `npm view ... bugs --json` returns no issue tracker metadata. Adding `bugs.url` gives npm users and package tooling a direct issue-reporting link.

## Verification

```sh
npm view expo-mcp@0.2.4 name version repository bugs --json
npm view @expo/mcp-tunnel@0.2.4 name version repository bugs --json
node - <<'NODE'
for (const path of ['./packages/expo-mcp/package.json','./packages/mcp-tunnel/package.json']) {
  const p=require(path);
  if(!p.repository?.url||!p.bugs?.url) process.exit(1);
  console.log(p.name, p.repository.url, p.bugs.url);
}
NODE
npm pack --dry-run --ignore-scripts ./packages/expo-mcp
npm pack --dry-run --ignore-scripts ./packages/mcp-tunnel
git diff --check
```
