### PR TITLE
fix(expo-mcp): add bugs.url metadata field to package.json

### DIFF
--- a/packages/expo-mcp/package.json
+++ b/packages/expo-mcp/package.json
@@ -53,5 +53,8 @@
     "memfs": "catalog:",
     "prettier": "catalog:",
     "typescript": "catalog:"
+  },
+  "bugs": {
+    "url": "https://github.com/expo/expo-mcp/issues"
   }
 }


### PR DESCRIPTION
This adds the missing `bugs.url` field to the expo-mcp package.json.

Closes charles-openclaw/charles-microbounties#336