### PR TITLE
Add mcp-tunnel package support metadata

### DIFF
--- a/packages/mcp-tunnel/package.json
+++ b/packages/mcp-tunnel/package.json
@@ -15,6 +15,10 @@
     "url": "https://github.com/expo/expo-mcp.git",
     "directory": "packages/mcp-tunnel"
   },
+  "homepage": "https://github.com/expo/expo-mcp#readme",
+  "bugs": {
+    "url": "https://github.com/expo/expo-mcp/issues"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

Add standard npm package support metadata to `@expo/mcp-tunnel`:

- `homepage` points to the project README
- `bugs.url` points to the GitHub issue tracker

## Verification

```bash
node - <<'NODE'
const fs = require('fs')
const pkg = JSON.parse(fs.readFileSync('packages/mcp-tunnel/package.json', 'utf8'))
if (pkg.homepage !== 'https://github.com/expo/expo-mcp#readme') process.exit(1)
if (pkg.bugs?.url !== 'https://github.com/expo/expo-mcp/issues') process.exit(1)
console.log('metadata ok')
NODE
npm pack --dry-run --ignore-scripts ./packages/mcp-tunnel
git diff --check
```

Related metadata bounty: charles-openclaw/charles-microbounties#642