### PR TITLE
[mcp] add tool annotations

### DIFF
--- a/packages/expo-mcp/src/mcp/tools.ts
+++ b/packages/expo-mcp/src/mcp/tools.ts
@@ -7,6 +7,7 @@ import { createLogCollector } from '../develop/LogCollectorFactory.js';
 import { findDevServerUrlAsync, openDevtoolsAsync } from '../develop/devtools.js';
 import { isExpoRouterProject } from '../project.js';
 import { addAutomationTools } from './tools/automation.js';
+import { platformInput, projectRootInput } from './tools/schemas.js';
 
 export function addMcpTools(server: McpServerProxy, projectRoot: string) {
   const isRouterProject = isExpoRouterProject(projectRoot);
@@ -16,7 +17,11 @@ export function addMcpTools(server: McpServerProxy, projectRoot: string) {
       {
         title: 'Query the sitemap of the current expo-router project',
         description:
-          'Query the all routes of the current expo-router project. This is useful if you were using expo-router and want to know all the routes of the app',
+          'List all routes (the sitemap) of the current Expo Router project. Use this when you are working with Expo Router and need to know which routes or screens exist in the app.',
+        annotations: {
+          readOnlyHint: true,
+          openWorldHint: false,
+        },
       },
       async () => {
         const sitemap = await within(async () => {
@@ -33,10 +38,17 @@ export function addMcpTools(server: McpServerProxy, projectRoot: string) {
     'open_devtools',
     {
       title: 'Open devtools',
-      description: 'Open the React Native DevTools',
+      description:
+        'Open React Native DevTools for the running app to debug JavaScript, inspect the component tree, and view console output. Requires a running dev server (Metro) for the project.',
       inputSchema: {
-        projectRoot: z.string(),
-        platform: z.enum(['android', 'ios']).optional(),
+        projectRoot: projectRootInput,
+        platform: platformInput,
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
     },
     async ({ projectRoot, platform: platformParam }) => {
@@ -63,16 +75,27 @@ export function addMcpTools(server: McpServerProxy, projectRoot: string) {
     'collect_app_logs',
     {
       title: 'Collect app logs',
-      description: 'Collect logs from native device (logcat/syslog) or JavaScript console',
+      description:
+        'Collect logs over a short time window from the native device (Android logcat / iOS syslog) and/or the JavaScript console. Use this to debug runtime errors, crashes, or unexpected behavior in a running app.',
       inputSchema: {
-        projectRoot: z.string(),
+        projectRoot: projectRootInput,
         sources: z
           .array(z.enum(['native_android', 'native_ios', 'js_console']))
           .min(1)
           .default(['js_console'])
           .describe('Log sources: logcat, syslog, or console.log'),
-        appId: z.string().optional(),
-        durationMs: z.number().min(0).max(10000).default(2000),
+        appId: z
+          .string()
+          .optional()
+          .describe(
+            'Application or bundle identifier to scope native logs to. Defaults to the project app id if omitted.'
+          ),
+        durationMs: z
+          .number()
+          .min(0)
+          .max(10000)
+          .default(2000)
+          .describe('How long to collect logs for, in milliseconds.'),
         filter: z
           .string()
           .optional()
@@ -85,6 +108,10 @@ export function addMcpTools(server: McpServerProxy, projectRoot: string) {
           .describe(
             'Log level filter (e.g., error, warn, info, debug). Only logs with this level will be returned'
           ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
       },
     },
     async ({ projectRoot, sources, appId: appIdParam, durationMs, filter, logLevel }) => {

--- a/packages/expo-mcp/src/mcp/tools/automation.ts
+++ b/packages/expo-mcp/src/mcp/tools/automation.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import { z } from 'zod';
 import { tmpfile } from 'zx';
 
+import { platformInput, projectRootInput } from './schemas.js';
 import type { IAutomation } from '../../automation/Automation.types.js';
 import { AutomationFactory } from '../../automation/AutomationFactory.js';
 import { resizeImageToMaxSizeAsync } from '../../imageUtils.js';
@@ -31,16 +32,22 @@ export function addAutomationTools(server: McpServerProxy, projectRoot: string) 
     {
       title: 'Tap on device',
       description:
-        'Tap on the device at the given coordinates (x, y) or by react-native testID. Provide either (x AND y) or testID.',
+        'Tap on the running app at the given screen coordinates (x, y) or on the view with the given React Native testID. Provide either both x and y, or testID. Prefer testID when available, as it is resilient to layout changes.',
       inputSchema: {
-        projectRoot: z.string(),
-        platform: z.enum(['android', 'ios']).optional(),
+        projectRoot: projectRootInput,
+        platform: platformInput,
         x: z.number().optional().describe('X coordinate for tap (required if testID not provided)'),
         y: z.number().optional().describe('Y coordinate for tap (required if testID not provided)'),
         testID: z
           .string()
           .optional()
           .describe('React Native testID of the view to tap (alternative to x,y coordinates)'),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
       },
     },
     async ({ projectRoot, platform, x, y, testID }) => {
@@ -71,16 +78,20 @@ export function addAutomationTools(server: McpServerProxy, projectRoot: string) 
     {
       title: 'Take screenshot of the app',
       description:
-        'Take screenshot of the full app or a specific view by react-native testID. Optionally provide testID to screenshot a specific view.',
+        'Take a screenshot of the running app — the full screen, or a specific view if a React Native testID is provided. Use this to visually verify the current UI state.',
       inputSchema: {
-        projectRoot: z.string(),
-        platform: z.enum(['android', 'ios']).optional(),
+        projectRoot: projectRootInput,
+        platform: platformInput,
         testID: z
           .string()
           .optional()
           .describe(
             'React Native testID of the view to screenshot (if not provided, takes full screen)'
           ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
       },
     },
     async ({ projectRoot, platform, testID }) => {
@@ -107,11 +118,15 @@ export function addAutomationTools(server: McpServerProxy, projectRoot: string) 
     {
       title: 'Find view properties',
       description:
-        'Find view and dump its properties. This is useful to verify the view is rendered correctly',
+        'Find a view by its React Native testID and return its properties (position, size, and visibility). Use this to verify a view rendered correctly, or to obtain coordinates before calling automation_tap.',
       inputSchema: {
-        projectRoot: z.string(),
-        platform: z.enum(['android', 'ios']).optional(),
+        projectRoot: projectRootInput,
+        platform: platformInput,
         testID: z.string().describe('React Native testID of the view to inspect'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
       },
     },
     async ({ projectRoot, platform, testID }) => {

--- a/packages/expo-mcp/src/mcp/tools/schemas.ts
+++ b/packages/expo-mcp/src/mcp/tools/schemas.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+/**
+ * Shared input schemas reused across tools, so the description and validation
+ * for common params stay consistent and live in one place.
+ */
+
+/** Absolute path to the project root. Passed per call so one server can work with multiple projects. */
+export const projectRootInput = z.string().describe('Absolute path to the project root.');
+
+/** Target platform; falls back to the currently running platform when omitted. */
+export const platformInput = z.enum(['android', 'ios']).optional();


### PR DESCRIPTION
# Why

be agent friendly

# How

- for `registerTool`, add annotations
- for `registerTool`, review descriptions

# Test Plan

ci passed 